### PR TITLE
Use h2 in-memory database for testing

### DIFF
--- a/backend/config/workload.yaml
+++ b/backend/config/workload.yaml
@@ -19,7 +19,7 @@ spec:
         autoscaling.knative.dev/minScale: "1"
     - name: testing_pipeline_matching_labels
       value:
-        apps.tanzu.vmware.com/pipeline: test-java
+        apps.tanzu.vmware.com/pipeline: test
     - name: api_descriptor
       value:
         type: openapi

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,10 +25,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>1.17.3</version>
-            <scope>test</scope>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,4 +1,4 @@
 
-spring.datasource.url=jdbc:tc:postgresql:14:////postgres
-spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
 spring.test.database.replace=NONE


### PR DESCRIPTION
This simplifies testing and we can use the standard `developer-defined-tekton-pipeline` pipeline.